### PR TITLE
replace np.pad with np.zeros and fancy indexing

### DIFF
--- a/image_misc.py
+++ b/image_misc.py
@@ -224,7 +224,9 @@ def tile_images_make_tiles(data, padsize=1, padval=0, hw=None, highlights = None
     if len(padval) == 1:
         data = np.pad(data, padding, mode='constant', constant_values=(padval, padval))
     else:
-        data = np.pad(data, padding, mode='constant', constant_values=(0, 0))
+        data_big = np.zeros((width*height, data.shape[1] + 2*padsize, data.shape[2] + 2*padsize, 3))
+        data_big[:-width*height + data.shape[0], padsize:-padsize, padsize:-padsize, :] = data
+        data = data_big
         for cc in (0,1,2):
             # Replace 0s with proper color in each channel
             data[:padding[0][0],  :, :, cc] = padval[cc]


### PR DESCRIPTION
for some reason np.pad was taking ~4 seconds per iteration and this was killing the frame rate. May have something to do with running within docker, but at the same time this change shouldn't effect running _outside_ docker.
